### PR TITLE
Allow inherit to work on fields in other contexts

### DIFF
--- a/index.php
+++ b/index.php
@@ -8,7 +8,7 @@ Kirby::plugin('microman/inherit', [
 				return $field;
 			}
 
-			$page = $page ?? page();
+			$page = $page ?? $field->parent() ?? page();
 			$field = $page->content()->get($field->key());
 				
 			if ($field->isEmpty() && is_a($page, "Kirby\Cms\Page")) {


### PR DESCRIPTION
Like in routes. The page is null in that case, but the field knows its parent (page) and thus it still works.